### PR TITLE
Add trailing commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For example:
     "hex": 0xFF,              #
     "binary": 0b1000_0001,     # Number literals can have _'s 
 
-    "lists": [1,2,3],         # Lists can have trailing commas
+    "lists": [1,2,3,],         # Lists can have trailing commas
 
     "strings": "At least \x61 \u0061 and \U00000061 work now",
     "or": 'a string',          # both "" and '' work.

--- a/SPEC.md
+++ b/SPEC.md
@@ -13,7 +13,7 @@ For example:
     "hex": 0xFF,              # Numbers don't have to be decimal
     "binary": 0b1000_0001,    # and numbers can have _'s too
 
-    "lists": [1,2,3],         # Lists can have trailing commas
+    "lists": [1,2,3,],         # Lists can have trailing commas
 
     "strings": "At least \x61 \u0061 and \U00000061 work now",
     "or": 'a string',         # Strings use either "" or ''.


### PR DESCRIPTION
README and SPEC both have the comment that lists can have trailing commas, but the example list shown doesn't actually reflect this.

Here is a low effort PR to change that :)